### PR TITLE
Replace obsoleted image-animated-p with image-multi-frame-p

### DIFF
--- a/phabricator.el
+++ b/phabricator.el
@@ -115,7 +115,7 @@ ring and messaged in the minibuffer."
   "Insert image NAME from a list of Phabricator macros."
   (interactive  `(,(arc--list-macros)))
   (let ((img (->> name arc-get-macro create-image)))
-    (when (image-animated-p img)
+    (when (image-multi-frame-p img)
       (image-animate img 0 t))
     (insert-image img name)
     (insert "\n\n")))


### PR DESCRIPTION
image-animated-p was a obsoleted function since Emacs 24.4. There is following byte-compile warning about this.

```
phabricator.el:118:29:Warning: `image-animated-p' is an obsolete function (as
    of 24.4); use `image-multi-frame-p' instead.
```
